### PR TITLE
Fix landing page redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="refresh" content="0; url=https://play.google.com/store/apps/details?id=com.ai.pollpe">
   <meta name="description" content="Earn Paytm and UPI cash by sharing your opinion on PollPe surveys. Get ₹100 instantly and withdraw directly to Paytm or UPI.">
   <title>PollPe - Earn Paytm & UPI Cash</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- stop automatically redirecting to Play Store by removing the meta refresh tag

## Testing
- `npm test` *(fails: Could not read package.json)*
- `yarn test` *(fails: No project found)*

------
https://chatgpt.com/codex/tasks/task_e_686d51e1bb2c832583467f64731d0e6f